### PR TITLE
SetSnaplen to better control read parameters

### DIFF
--- a/pcapgo/read.go
+++ b/pcapgo/read.go
@@ -149,6 +149,11 @@ func (r *Reader) Snaplen() uint32 {
 	return r.snaplen
 }
 
+// SetSnaplen sets the snapshot length of the capture file.
+func (r *Reader) SetSnaplen(newSnaplen uint32) {
+	r.snaplen = newSnaplen
+}
+
 // Reader formater
 func (r *Reader) String() string {
 	return fmt.Sprintf("PcapFile  maj: %x min: %x snaplen: %d linktype: %s", r.versionMajor, r.versionMinor, r.snaplen, r.linkType)


### PR DESCRIPTION
To better control what packet size to allow to read and what packet size to dump